### PR TITLE
Better comfortable mode story text

### DIFF
--- a/lib/ui/pages/story/story_query.dart
+++ b/lib/ui/pages/story/story_query.dart
@@ -166,6 +166,7 @@ class StoryTile extends StatelessWidget {
 
     final subTitle = settings.displayDensity == DisplayDensity.comfortable
         ? Container(
+            padding: EdgeInsets.symmetric(vertical: 5.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[

--- a/lib/ui/pages/story_detail/story_detail_query.dart
+++ b/lib/ui/pages/story_detail/story_detail_query.dart
@@ -75,8 +75,13 @@ class StoryDetail extends StatelessWidget {
     final TextTheme textTheme = theme.textTheme;
     String markdown = html2md.convert(story.content);
 
+    final customMarkdownStyleSheet = MarkdownStyleSheet
+        .fromTheme(theme)
+        .copyWith(p: textTheme.body1.copyWith(fontSize: 15));
+
     final content = MarkdownBody(
       data: markdown,
+      styleSheet: customMarkdownStyleSheet,
       onTapLink: (link) async {
         if (await canLaunch(link)) {
           await launch(link);


### PR DESCRIPTION
Issue: https://github.com/chimon2000/hashnode/issues/3

Before extend markdown style (default font size is 14)
![Screen Shot 2019-10-03 at 9 12 20 PM](https://user-images.githubusercontent.com/40749524/66134699-e95d6780-e622-11e9-94a1-cd05b6b947d0.png)

After custom (font size of body text is 15)
![Screen Shot 2019-10-03 at 9 11 50 PM](https://user-images.githubusercontent.com/40749524/66134645-d64a9780-e622-11e9-98f9-e5031cd4630a.png)

==============================================

Additionally, I also added a small vertical padding for the subtitle

Before
![Screen Shot 2019-10-03 at 9 05 38 PM](https://user-images.githubusercontent.com/40749524/66134917-4ce79500-e623-11e9-9b00-43c9610f8022.png)

After
![Screen Shot 2019-10-03 at 9 05 20 PM](https://user-images.githubusercontent.com/40749524/66134934-53760c80-e623-11e9-8c44-f60cc847534a.png)

